### PR TITLE
Typo fix

### DIFF
--- a/timezones/tz_utils.py
+++ b/timezones/tz_utils.py
@@ -240,7 +240,7 @@ class FixedOffset(tzinfo):
     def localize(self, dt, is_dst=False):
         '''Convert naive time to local time'''
         if dt.tzinfo is not None:
-            raise ValueError, 'Not naive datetime (tzinfo is already set)'
+            raise ValueError('Not naive datetime (tzinfo is already set)')
         return dt.replace(tzinfo=self)
 
     def __getinitargs__(self):


### PR DESCRIPTION
Was getting this when trying to import tz_utils.py

from timezones import zones
  File "/.../lib/python3.5/site-packages/timezones/tz_utils.py", line 243
    raise ValueError, 'Not naive datetime (tzinfo is already set)'
                    ^
SyntaxError: invalid syntax