### PR TITLE
Remove wrong "West Central Africa" timezone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='timezones',
-    version='2.0.4',
+    version='2.0.5',
     author="Doist Developers",
     author_email="dev@doist.com",
     url="https://doist.com",

--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -144,7 +144,6 @@ _ALL_TIMEZONES = [
     ("+0100", "Europe/Stockholm", '(GMT+0100) Stockholm'),
     ("+0100", "Europe/Vienna", '(GMT+0100) Vienna'),
     ("+0100", "Europe/Warsaw", '(GMT+0100) Warsaw'),
-    ("+0100", "Europe/Copenhagen", '(GMT+0100) West Central Africa'),
     ("+0100", "Europe/Zagreb", '(GMT+0100) Zagreb'),
     ("+0200", "Europe/Athens", '(GMT+0200) Athens'),
     ("+0200", "Europe/Bucharest", '(GMT+0200) Bucharest'),


### PR DESCRIPTION
There's no such timezone. However there's West Africa Time, which is already covered by Africa/Casablanca, and Central Africa Time, which is covered by Africa/Cairo.

Ref:
- https://time.is/CAT
- https://time.is/WAT