### PR TITLE
Make sure location.time_zone exists or return None

### DIFF
--- a/timezones/test_timezones.py
+++ b/timezones/test_timezones.py
@@ -40,6 +40,7 @@ def test_get_timezone():
 @pytest.mark.skip('Requires installed GeoIP2 database')
 def test_guess_timezone():
     tz_utils.GEOIP_DATA_LOCATION = '/usr/local/geo_ip/GeoIP2-City.mmdb'
+    assert not tz_utils.guess_timezone_by_ip('70.132.4.78')
     assert tz_utils.guess_timezone_by_ip(
         '201.246.115.62', only_name=True) == 'America/Santiago'
     assert tz_utils.guess_timezone_by_ip(

--- a/timezones/tz_utils.py
+++ b/timezones/tz_utils.py
@@ -57,6 +57,7 @@ GEOIP_DATA_LOCATION = None
 # --- Functions ----------------------------------------------
 def guess_timezone_by_ip(ip, only_name=False):
     """Given an `ip` with guess timezone using geoip2.
+    Returns a tuple of (tz_offets, tz_name, tz_formated).
     `None` is returned if it can't guess a timezone.
 
     For this to work you need to set tz_utils.GEOIP_DATA_LOCATION
@@ -75,12 +76,11 @@ def guess_timezone_by_ip(ip, only_name=False):
             record = geo_lib.city(ip)
             if record:
                 location = record.location
-                if location:
-                    timezone = location.time_zone
+                if location and location.time_zone:
                     if only_name:
-                        return timezone
+                        return location.timezone
                     else:
-                        return format_tz_by_name(timezone)
+                        return format_tz_by_name(location.timezone)
         except:
             record = None
     return None


### PR DESCRIPTION
It seems like when the predicted location does not have time_zone attribute, it tends to return corrupted timezone value like ["",null,"(GMT) None"]`, instead of just None.

We can check this at the first possible entrypoint before the output is even constructed.