### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages=["timezones"],
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     install_requires=["geoip2", "pytz", "future"],
     platforms=["Any"],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages=["timezones"],

--- a/timezones/tz_utils.py
+++ b/timezones/tz_utils.py
@@ -41,8 +41,9 @@ import pytz
 
 try:
     import geoip2.database as geoip2_db
+    HAS_GEOIP2 = True
 except ImportError:
-    geoip2_db = None
+    HAS_GEOIP2 = False
 
 # --- Exports ----------------------------------------------
 __all__ = [
@@ -135,7 +136,7 @@ GEO_IP = None
 def _get_geoip_lib():
     global GEO_IP
 
-    if not GEOIP_DATA_LOCATION:
+    if not HAS_GEOIP2 or not GEOIP_DATA_LOCATION:
         return None
 
     try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38
+envlist = py27, py35, py36, py37, py38, mypy
 
 [gh-actions]
 python =
@@ -7,10 +7,16 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37
-    3.8: py38
+    3.8: py38, mypy
 
 [testenv]
 deps =
     pytest
 commands =
     pytest {posargs}
+
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy timezones {posargs:--ignore-missing-imports}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py27, py35, py36, py37
+
+[gh-actions]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
 
 [testenv]
 deps =


### PR DESCRIPTION
Just as described. Add CI using GitHub actions.

Tests are run with Tox for all the supported Python versions. Since They fail on 3.5, this also fixes them.

This also adds support for Python 3.8 and type checking with Mypy. These could (*should*) be moved to separate PRs, but it's easier to do it at once. Let me know if you'd prefer that I split this into several PRs 😉