### PR TITLE
Fixed a typo and skipping of a crucial test

### DIFF
--- a/timezones/test_timezones.py
+++ b/timezones/test_timezones.py
@@ -1,7 +1,10 @@
+import os
 import pytest
 import pytz
 import datetime
 from timezones import zones, tz_utils, tz_rendering
+
+GEOIP_DATA_LOCATION = '/usr/local/geo_ip/GeoIP2-City.mmdb'
 
 
 def test_sort():
@@ -38,8 +41,13 @@ def test_get_timezone():
 
 
 @pytest.mark.skip('Requires installed GeoIP2 database')
+def no_geolib():
+    return not os.path.exists(GEOIP_DATA_LOCATION)
+
+
+@pytest.mark.skipif(no_geolib() is True, reason='Requires GeoIP2 database')
 def test_guess_timezone():
-    tz_utils.GEOIP_DATA_LOCATION = '/usr/local/geo_ip/GeoIP2-City.mmdb'
+    tz_utils.GEOIP_DATA_LOCATION = GEOIP_DATA_LOCATION
     assert not tz_utils.guess_timezone_by_ip('70.132.4.78')
     assert tz_utils.guess_timezone_by_ip(
         '201.246.115.62', only_name=True) == 'America/Santiago'

--- a/timezones/test_timezones.py
+++ b/timezones/test_timezones.py
@@ -40,7 +40,6 @@ def test_get_timezone():
     assert tz_utils.is_valid_timezone('Europe/Moscow1') is False
 
 
-@pytest.mark.skip('Requires installed GeoIP2 database')
 def no_geolib():
     return not os.path.exists(GEOIP_DATA_LOCATION)
 

--- a/timezones/tz_utils.py
+++ b/timezones/tz_utils.py
@@ -79,9 +79,9 @@ def guess_timezone_by_ip(ip, only_name=False):
                 location = record.location
                 if location and location.time_zone:
                     if only_name:
-                        return location.timezone
+                        return location.time_zone
                     else:
-                        return format_tz_by_name(location.timezone)
+                        return format_tz_by_name(location.time_zone)
         except:
             record = None
     return None


### PR DESCRIPTION
## Issue
We use `location.timezone` instead of `location.time_zone`. We also skip a critical test always. We should only skip if the GeoIP database isn't installed.

## Backstory

I debugged this with @hostmaster; we initially thought it was related to how our systems were set up.

@imankulov @Schnouki, this is a quite critical bug as it means that `guess_timezone_by_ip` is not working for this lib. So everyone is most likely signing up with a UTC timezone.