### PR TITLE
Reorder zones list so that city of the naming of the timezone comes last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,12 @@ pip-log.txt
 .coverage
 .tox
 
-#Translations
+# Translations
 *.mo
 
-#Mr Developer
+# Mr Developer
 .mr.developer.cfg
+
+# Utils
+env
+.vscode

--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -25,6 +25,7 @@ import re
 
 from future.backports import cmp_to_key
 from past.builtins import cmp
+
 from timezones import tz_utils
 
 _UPDATED_TZS = False
@@ -205,8 +206,8 @@ _ALL_TIMEZONES = [
     ("+0800", "Asia/Kuala_Lumpur", '(GMT+0800) Kuala Lumpur'),
     ("+0800", "Australia/Perth", '(GMT+0800) Perth'),
     ("+0800", "Singapore", '(GMT+0800) Singapore'),
-    ("+0800", "Asia/Taipei", '(GMT+0800) Taipei'),
     ("+0800", "Asia/Taipei", '(GMT+0800) Ulaan Bataar'),
+    ("+0800", "Asia/Taipei", '(GMT+0800) Taipei'),
     ("+0900", "Asia/Seoul", '(GMT+0900) Seoul'),
     ("+0900", "Asia/Tokyo", '(GMT+0900) Tokyo'),
     ("+0900", "Asia/Yakutsk", '(GMT+0900) Yakutsk'),

--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -166,7 +166,7 @@ _ALL_TIMEZONES = [
     ("+0300", "Africa/Nairobi", '(GMT+0300) Nairobi'),
     ("+0300", "Asia/Riyadh", '(GMT+0300) Riyadh'),
     ("+0300", "Europe/Moscow", '(GMT+0300) St. Petersburg'),
-    ("+0400", "Europe/Volgograd", '(GMT+0300) Volgograd'),
+    ("+0300", "Europe/Volgograd", '(GMT+0300) Volgograd'),
     ("+0330", "Asia/Tehran", '(GMT+0330) Tehran'),
     ("+0400", "Asia/Dubai", '(GMT+0400) Abu Dhabi'),
     ("+0400", "Asia/Baku", '(GMT+0400) Baku'),

--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -166,7 +166,7 @@ _ALL_TIMEZONES = [
     ("+0300", "Africa/Nairobi", '(GMT+0300) Nairobi'),
     ("+0300", "Asia/Riyadh", '(GMT+0300) Riyadh'),
     ("+0300", "Europe/Moscow", '(GMT+0300) St. Petersburg'),
-    ("+0400", "Europe/Volgograd", '(GMT+0400) Volgograd'),
+    ("+0400", "Europe/Volgograd", '(GMT+0300) Volgograd'),
     ("+0330", "Asia/Tehran", '(GMT+0330) Tehran'),
     ("+0400", "Asia/Dubai", '(GMT+0400) Abu Dhabi'),
     ("+0400", "Asia/Baku", '(GMT+0400) Baku'),


### PR DESCRIPTION
Issue: https://github.com/Doist/Issues/issues/1732

Discovered through test failing, this PR also has an additional change of Updating `Volgograd`'s timezone from `+4` to `+3`. For refernece, please see:
- https://techcommunity.microsoft.com/t5/daylight-saving-time-time-zone/interim-guidance-on-2020-time-zone-updates-for-volgograd-russia/ba-p/2014425
- https://www.timeanddate.com/time/zone/russia/volgograd
