### PR TITLE
Add test for obsolete names

### DIFF
--- a/timezones/test_timezones.py
+++ b/timezones/test_timezones.py
@@ -1,5 +1,7 @@
-import datetime
 import os.path
+import re
+import zoneinfo
+from importlib import resources
 
 import pytest
 
@@ -114,9 +116,27 @@ def test_valid_offset(offset_str, tzname, verbose_name):
     expected_offset = "%s%02d%02d" % (offset_sign, offset_hours, offset_minutes)
     assert offset_str == expected_offset, "Invalid offset for {}".format(tzname)
 
+    zoneinfo.available_timezones()
+
     # 3. Test verbose name
     assert verbose_name.startswith("(GMT%s) " % expected_offset)
 
+
+@pytest.fixture(scope="session")
+def obsolete_names():
+    obsolete_names = {}
+    with open("tzdata2023c/backward", "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith("Link\t"):
+                continue
+            _link, dest, source, *_ = re.split("\t+", line)
+            obsolete_names[source] = dest
+    return obsolete_names
+
+@pytest.mark.parametrize("_offset_str,tzname,_verbose_name", zones.get_timezones())
+def test_obsolete_names(_offset_str, tzname, _verbose_name, obsolete_names):
+    assert tzname not in obsolete_names.keys(), f"{tzname} is obsolete, use {obsolete_names[tzname]} instead"
 
 def test_get_timezones_json():
     json_list = tz_rendering.get_timezones_json()

--- a/tzdata2023c/backward
+++ b/tzdata2023c/backward
@@ -1,0 +1,319 @@
+# tzdb links for backward compatibility
+
+# This file is in the public domain, so clarified as of
+# 2009-05-17 by Arthur David Olson.
+
+# This file provides links from old or merged timezone names to current ones.
+# Many names changed in 1993 and in 1995, and many merged names moved here
+# in the period from 2013 through 2022.  Several of these names are
+# also present in the file 'backzone', which has data important only
+# for pre-1970 timestamps and so is out of scope for tzdb proper.
+
+# Although this file is optional and tzdb will work if you omit it by
+# building with 'make BACKWARD=', in practice downstream users
+# typically use this file for backward compatibility.
+
+# This file is divided into sections, one for each major reason for a
+# backward compatibility link.  Each section is sorted by link name.
+
+# A "#= TARGET1" comment labels each link inserted only because some
+# .zi parsers (including tzcode through 2022e) mishandle links to links.
+# The comment says what the target would be if these parsers were fixed
+# so that data could contain links to links.  For example, the line
+# "Link Australia/Sydney Australia/ACT #= Australia/Canberra" would be
+# "Link Australia/Canberra Australia/ACT" were it not that data lines
+# refrain from linking to links like Australia/Canberra, which means
+# the Australia/ACT line links instead to Australia/Sydney,
+# Australia/Canberra's target.
+
+
+# Pre-1993 naming conventions
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Australia/Sydney	Australia/ACT	#= Australia/Canberra
+Link	Australia/Lord_Howe	Australia/LHI
+Link	Australia/Sydney	Australia/NSW
+Link	Australia/Darwin	Australia/North
+Link	Australia/Brisbane	Australia/Queensland
+Link	Australia/Adelaide	Australia/South
+Link	Australia/Hobart	Australia/Tasmania
+Link	Australia/Melbourne	Australia/Victoria
+Link	Australia/Perth		Australia/West
+Link	Australia/Broken_Hill	Australia/Yancowinna
+Link	America/Rio_Branco	Brazil/Acre	#= America/Porto_Acre
+Link	America/Noronha		Brazil/DeNoronha
+Link	America/Sao_Paulo	Brazil/East
+Link	America/Manaus		Brazil/West
+Link	America/Halifax		Canada/Atlantic
+Link	America/Winnipeg	Canada/Central
+# This line is commented out, as the name exceeded the 14-character limit
+# and was an unused misnomer.
+#Link	America/Regina		Canada/East-Saskatchewan
+Link	America/Toronto		Canada/Eastern
+Link	America/Edmonton	Canada/Mountain
+Link	America/St_Johns	Canada/Newfoundland
+Link	America/Vancouver	Canada/Pacific
+Link	America/Regina		Canada/Saskatchewan
+Link	America/Whitehorse	Canada/Yukon
+Link	America/Santiago	Chile/Continental
+Link	Pacific/Easter		Chile/EasterIsland
+Link	America/Havana		Cuba
+Link	Africa/Cairo		Egypt
+Link	Europe/Dublin		Eire
+# Vanguard section, for most .zi parsers.
+#Link	GMT			Etc/GMT
+#Link	GMT			Etc/GMT+0
+#Link	GMT			Etc/GMT-0
+#Link	GMT			Etc/GMT0
+#Link	GMT			Etc/Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Link	Etc/GMT			Etc/GMT+0
+Link	Etc/GMT			Etc/GMT-0
+Link	Etc/GMT			Etc/GMT0
+Link	Etc/GMT			Etc/Greenwich
+# End of rearguard section.
+Link	Etc/UTC			Etc/UCT
+Link	Etc/UTC			Etc/Universal
+Link	Etc/UTC			Etc/Zulu
+Link	Europe/London		GB
+Link	Europe/London		GB-Eire
+# Vanguard section, for most .zi parsers.
+#Link	GMT			GMT+0
+#Link	GMT			GMT-0
+#Link	GMT			GMT0
+#Link	GMT			Greenwich
+# Rearguard section, for TZUpdater 2.3.2 and earlier.
+Link	Etc/GMT			GMT+0
+Link	Etc/GMT			GMT-0
+Link	Etc/GMT			GMT0
+Link	Etc/GMT			Greenwich
+# End of rearguard section.
+Link	Asia/Hong_Kong		Hongkong
+Link	Africa/Abidjan		Iceland	#= Atlantic/Reykjavik
+Link	Asia/Tehran		Iran
+Link	Asia/Jerusalem		Israel
+Link	America/Jamaica		Jamaica
+Link	Asia/Tokyo		Japan
+Link	Pacific/Kwajalein	Kwajalein
+Link	Africa/Tripoli		Libya
+Link	America/Tijuana		Mexico/BajaNorte
+Link	America/Mazatlan	Mexico/BajaSur
+Link	America/Mexico_City	Mexico/General
+Link	Pacific/Auckland	NZ
+Link	Pacific/Chatham		NZ-CHAT
+Link	America/Denver		Navajo	#= America/Shiprock
+Link	Asia/Shanghai		PRC
+Link	Europe/Warsaw		Poland
+Link	Europe/Lisbon		Portugal
+Link	Asia/Taipei		ROC
+Link	Asia/Seoul		ROK
+Link	Asia/Singapore		Singapore
+Link	Europe/Istanbul		Turkey
+Link	Etc/UTC			UCT
+Link	America/Anchorage	US/Alaska
+Link	America/Adak		US/Aleutian
+Link	America/Phoenix		US/Arizona
+Link	America/Chicago		US/Central
+Link	America/Indiana/Indianapolis	US/East-Indiana
+Link	America/New_York	US/Eastern
+Link	Pacific/Honolulu	US/Hawaii
+Link	America/Indiana/Knox	US/Indiana-Starke
+Link	America/Detroit		US/Michigan
+Link	America/Denver		US/Mountain
+Link	America/Los_Angeles	US/Pacific
+Link	Pacific/Pago_Pago	US/Samoa
+Link	Etc/UTC			UTC
+Link	Etc/UTC			Universal
+Link	Europe/Moscow		W-SU
+Link	Etc/UTC			Zulu
+
+
+# Two-part names that were renamed mostly to three-part names in 1995
+
+# Link	TARGET				LINK-NAME	#= TARGET1
+Link	America/Argentina/Buenos_Aires	America/Buenos_Aires
+Link	America/Argentina/Catamarca	America/Catamarca
+Link	America/Argentina/Cordoba	America/Cordoba
+Link	America/Indiana/Indianapolis	America/Indianapolis
+Link	America/Argentina/Jujuy		America/Jujuy
+Link	America/Indiana/Knox		America/Knox_IN
+Link	America/Kentucky/Louisville	America/Louisville
+Link	America/Argentina/Mendoza	America/Mendoza
+Link	America/Puerto_Rico		America/Virgin	#= America/St_Thomas
+Link	Pacific/Pago_Pago		Pacific/Samoa
+
+
+# Pre-2013 practice, which typically had a Zone per zone.tab line
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Accra
+Link	Africa/Nairobi		Africa/Addis_Ababa
+Link	Africa/Nairobi		Africa/Asmara
+Link	Africa/Abidjan		Africa/Bamako
+Link	Africa/Lagos		Africa/Bangui
+Link	Africa/Abidjan		Africa/Banjul
+Link	Africa/Maputo		Africa/Blantyre
+Link	Africa/Lagos		Africa/Brazzaville
+Link	Africa/Maputo		Africa/Bujumbura
+Link	Africa/Abidjan		Africa/Conakry
+Link	Africa/Abidjan		Africa/Dakar
+Link	Africa/Nairobi		Africa/Dar_es_Salaam
+Link	Africa/Nairobi		Africa/Djibouti
+Link	Africa/Lagos		Africa/Douala
+Link	Africa/Abidjan		Africa/Freetown
+Link	Africa/Maputo		Africa/Gaborone
+Link	Africa/Maputo		Africa/Harare
+Link	Africa/Nairobi		Africa/Kampala
+Link	Africa/Maputo		Africa/Kigali
+Link	Africa/Lagos		Africa/Kinshasa
+Link	Africa/Lagos		Africa/Libreville
+Link	Africa/Abidjan		Africa/Lome
+Link	Africa/Lagos		Africa/Luanda
+Link	Africa/Maputo		Africa/Lubumbashi
+Link	Africa/Maputo		Africa/Lusaka
+Link	Africa/Lagos		Africa/Malabo
+Link	Africa/Johannesburg	Africa/Maseru
+Link	Africa/Johannesburg	Africa/Mbabane
+Link	Africa/Nairobi		Africa/Mogadishu
+Link	Africa/Lagos		Africa/Niamey
+Link	Africa/Abidjan		Africa/Nouakchott
+Link	Africa/Abidjan		Africa/Ouagadougou
+Link	Africa/Lagos		Africa/Porto-Novo
+Link	America/Puerto_Rico	America/Anguilla
+Link	America/Puerto_Rico	America/Antigua
+Link	America/Puerto_Rico	America/Aruba
+Link	America/Panama		America/Atikokan
+Link	America/Puerto_Rico	America/Blanc-Sablon
+Link	America/Panama		America/Cayman
+Link	America/Phoenix		America/Creston
+Link	America/Puerto_Rico	America/Curacao
+Link	America/Puerto_Rico	America/Dominica
+Link	America/Puerto_Rico	America/Grenada
+Link	America/Puerto_Rico	America/Guadeloupe
+Link	America/Puerto_Rico	America/Kralendijk
+Link	America/Puerto_Rico	America/Lower_Princes
+Link	America/Puerto_Rico	America/Marigot
+Link	America/Puerto_Rico	America/Montserrat
+Link	America/Toronto		America/Nassau
+Link	America/Puerto_Rico	America/Port_of_Spain
+Link	America/Puerto_Rico	America/St_Barthelemy
+Link	America/Puerto_Rico	America/St_Kitts
+Link	America/Puerto_Rico	America/St_Lucia
+Link	America/Puerto_Rico	America/St_Thomas
+Link	America/Puerto_Rico	America/St_Vincent
+Link	America/Puerto_Rico	America/Tortola
+Link	Pacific/Port_Moresby	Antarctica/DumontDUrville
+Link	Pacific/Auckland	Antarctica/McMurdo
+Link	Asia/Riyadh		Antarctica/Syowa
+Link	Asia/Urumqi		Antarctica/Vostok
+Link	Europe/Berlin		Arctic/Longyearbyen
+Link	Asia/Riyadh		Asia/Aden
+Link	Asia/Qatar		Asia/Bahrain
+Link	Asia/Kuching		Asia/Brunei
+Link	Asia/Singapore		Asia/Kuala_Lumpur
+Link	Asia/Riyadh		Asia/Kuwait
+Link	Asia/Dubai		Asia/Muscat
+Link	Asia/Bangkok		Asia/Phnom_Penh
+Link	Asia/Bangkok		Asia/Vientiane
+Link	Africa/Abidjan		Atlantic/Reykjavik
+Link	Africa/Abidjan		Atlantic/St_Helena
+Link	Europe/Brussels		Europe/Amsterdam
+Link	Europe/Prague		Europe/Bratislava
+Link	Europe/Zurich		Europe/Busingen
+Link	Europe/Berlin		Europe/Copenhagen
+Link	Europe/London		Europe/Guernsey
+Link	Europe/London		Europe/Isle_of_Man
+Link	Europe/London		Europe/Jersey
+Link	Europe/Belgrade		Europe/Ljubljana
+Link	Europe/Brussels		Europe/Luxembourg
+Link	Europe/Helsinki		Europe/Mariehamn
+Link	Europe/Paris		Europe/Monaco
+Link	Europe/Berlin		Europe/Oslo
+Link	Europe/Belgrade		Europe/Podgorica
+Link	Europe/Rome		Europe/San_Marino
+Link	Europe/Belgrade		Europe/Sarajevo
+Link	Europe/Belgrade		Europe/Skopje
+Link	Europe/Berlin		Europe/Stockholm
+Link	Europe/Zurich		Europe/Vaduz
+Link	Europe/Rome		Europe/Vatican
+Link	Europe/Belgrade		Europe/Zagreb
+Link	Africa/Nairobi		Indian/Antananarivo
+Link	Asia/Bangkok		Indian/Christmas
+Link	Asia/Yangon		Indian/Cocos
+Link	Africa/Nairobi		Indian/Comoro
+Link	Indian/Maldives		Indian/Kerguelen
+Link	Asia/Dubai		Indian/Mahe
+Link	Africa/Nairobi		Indian/Mayotte
+Link	Asia/Dubai		Indian/Reunion
+Link	Pacific/Port_Moresby	Pacific/Chuuk
+Link	Pacific/Tarawa		Pacific/Funafuti
+Link	Pacific/Tarawa		Pacific/Majuro
+Link	Pacific/Pago_Pago	Pacific/Midway
+Link	Pacific/Guadalcanal	Pacific/Pohnpei
+Link	Pacific/Guam		Pacific/Saipan
+Link	Pacific/Tarawa		Pacific/Wake
+Link	Pacific/Tarawa		Pacific/Wallis
+
+
+# Non-zone.tab locations with timestamps since 1970 that duplicate
+# those of an existing location
+
+# Link	TARGET			LINK-NAME
+Link	Africa/Abidjan		Africa/Timbuktu
+Link	America/Argentina/Catamarca	America/Argentina/ComodRivadavia
+Link	America/Adak		America/Atka
+Link	America/Panama		America/Coral_Harbour
+Link	America/Tijuana		America/Ensenada
+Link	America/Indiana/Indianapolis	America/Fort_Wayne
+Link	America/Toronto		America/Montreal
+Link	America/Toronto		America/Nipigon
+Link	America/Iqaluit		America/Pangnirtung
+Link	America/Rio_Branco	America/Porto_Acre
+Link	America/Winnipeg	America/Rainy_River
+Link	America/Argentina/Cordoba	America/Rosario
+Link	America/Tijuana		America/Santa_Isabel
+Link	America/Denver		America/Shiprock
+Link	America/Toronto		America/Thunder_Bay
+Link	America/Edmonton	America/Yellowknife
+Link	Pacific/Auckland	Antarctica/South_Pole
+Link	Asia/Shanghai		Asia/Chongqing
+Link	Asia/Shanghai		Asia/Harbin
+Link	Asia/Urumqi		Asia/Kashgar
+Link	Asia/Jerusalem		Asia/Tel_Aviv
+Link	Europe/Berlin		Atlantic/Jan_Mayen
+Link	Australia/Sydney	Australia/Canberra
+Link	Australia/Hobart	Australia/Currie
+Link	Europe/London		Europe/Belfast
+Link	Europe/Chisinau		Europe/Tiraspol
+Link	Europe/Kyiv		Europe/Uzhgorod
+Link	Europe/Kyiv		Europe/Zaporozhye
+Link	Pacific/Kanton		Pacific/Enderbury
+Link	Pacific/Honolulu	Pacific/Johnston
+Link	Pacific/Port_Moresby	Pacific/Yap
+
+
+# Alternate names for the same location
+
+# Link	TARGET			LINK-NAME	#= TARGET1
+Link	Africa/Nairobi		Africa/Asmera	#= Africa/Asmara
+Link	America/Nuuk		America/Godthab
+Link	Asia/Ashgabat		Asia/Ashkhabad
+Link	Asia/Kolkata		Asia/Calcutta
+Link	Asia/Shanghai		Asia/Chungking	#= Asia/Chongqing
+Link	Asia/Dhaka		Asia/Dacca
+# Istanbul is in both continents.
+Link	Europe/Istanbul		Asia/Istanbul
+Link	Asia/Kathmandu		Asia/Katmandu
+Link	Asia/Macau		Asia/Macao
+Link	Asia/Yangon		Asia/Rangoon
+Link	Asia/Ho_Chi_Minh	Asia/Saigon
+Link	Asia/Thimphu		Asia/Thimbu
+Link	Asia/Makassar		Asia/Ujung_Pandang
+Link	Asia/Ulaanbaatar	Asia/Ulan_Bator
+Link	Atlantic/Faroe		Atlantic/Faeroe
+Link	Europe/Kyiv		Europe/Kiev
+# Classically, Cyprus is in Asia; e.g. see Herodotus, Histories, I.72.
+# However, for various reasons many users expect to find it under Europe.
+Link	Asia/Nicosia		Europe/Nicosia
+Link	Pacific/Guadalcanal	Pacific/Ponape	#= Pacific/Pohnpei
+Link	Pacific/Port_Moresby	Pacific/Truk	#= Pacific/Chuuk


### PR DESCRIPTION
While working on #40, I noticed we use several obsolete timezone names:

![python-timezones – _defs py 2023-10-04 at 11 39 49 AM](https://github.com/Doist/python-timezones/assets/102931/20ed33b9-2491-492c-87e9-c6d638efc44c)
 
For example, most of those `Europe/` should either be `Europe/Brussels` or `Europe/Prague` according to IANA.

On the one hand, I'm concerned about how much we're falling behind. E.g., it's been a long while since `America/Godthab` has been replaced with `America/Nuuk`.

On the other hand, if we follow IANA's deprecations, we'll greatly simplify our list, but we may lose some user-friendliness. E.g., `Europe/Copenhagen` is obsolete in favor of `Europe/Berlin` and would be completely gone. Is that OK?

Thoughts @amix?